### PR TITLE
Add CI: shellcheck, hadolint, image build and Trivy scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 99
-  reviewers:
-  - diogopms
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 99
+    reviewers:
+      - diogopms
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+    reviewers:
+      - diogopms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -e SC1091
+
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ftp-proxy-s3:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ftp-proxy-s3:ci
+          format: table
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          exit-code: "0"


### PR DESCRIPTION
## Summary
The repository had no CI. This adds a `CI` workflow (`.github/workflows/ci.yml`) that runs on every pull request and on pushes to `master`.

## Jobs
- **ShellCheck** — lints `*.sh` (sourced-file warning SC1091 disabled).
- **Hadolint** — lints the `Dockerfile`.
- **Build image** — builds with Buildx + GHA layer cache, then runs a **Trivy** scan for HIGH/CRITICAL OS/library CVEs (`ignore-unfixed`, non-blocking for now so it reports without failing the build).

## Also
- Registers the `github-actions` ecosystem with Dependabot so action versions stay current.

Least-privilege `contents: read` permissions and `cancel-in-progress` concurrency are set.