### PR TITLE
Add daily semantic-release with image publish to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+# Releases are cut on a schedule, not on merge. Merging to master only runs CI
+# (see ci.yml); the actual versioned release + image publish happens here once a
+# day, and only when there are new releasable commits since the last tag.
+on:
+  schedule:
+    - cron: "0 6 * * *" # daily at 06:00 UTC
+  workflow_dispatch: # allow a manual release run
+
+permissions:
+  contents: write # create tags / GitHub releases
+  packages: write # push the image to GHCR
+  issues: write # semantic-release comments on released issues/PRs
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    name: Semantic release
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.semantic.outputs.new_release_published }}
+      version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so commit analysis sees every tag
+
+      - name: Run semantic-release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits@^8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-image:
+    name: Build & push image
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.version }}
+            type=semver,pattern={{major}},value=${{ needs.release.outputs.version }}
+            type=raw,value=latest
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,26 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "revert", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary
Sets up an automated, versioned release cycle like other projects use, driven by **conventional commits** and **semantic-release**.

## Behaviour
- **Scheduled, not on merge.** `release.yml` runs on a daily cron (`0 6 * * *`) and via `workflow_dispatch`. Merging to `master` only runs CI — no release is cut on push.
- **Detects new commits.** `semantic-release` analyses conventional commits since the last tag. If nothing is releasable the run is a no-op; otherwise it computes the next **semantic version**, creates the git tag, and publishes a GitHub Release with generated notes.
- **Publishes the image.** When (and only when) a release is published, the image is built and pushed to **GHCR** tagged `X.Y.Z`, `X.Y`, `X`, and `latest`.

## Config
- `.releaserc.json` — `conventionalcommits` preset; `feat`→minor, `fix`/`perf`/`refactor`/`build`/`revert`→patch, `!`/BREAKING CHANGE→major.

## Notes
- Uses the built-in `GITHUB_TOKEN` (no extra secrets) with least-privilege per-job permissions.
- Conventional-commit guidance is documented in the docs PR (CONTRIBUTING.md).
