### PR TITLE
Harden shell scripts, fix S3 mount and EC2 metadata, dedup user logic

### DIFF
--- a/add_users_in_container.sh
+++ b/add_users_in_container.sh
@@ -1,65 +1,48 @@
-#!/bin/bash
-# This script will update the env.list file (file containing USERS environrment variable) and add the new users if there are any.
+#!/usr/bin/env bash
+#
+# Live-reload loop: periodically pulls the USERS list from the config bucket and
+# reconciles accounts (creating users, updating passwords) plus repairs file
+# permissions. The actual account logic is shared with users.sh.
+set -euo pipefail
 
-FTP_DIRECTORY="/home/aws/s3bucket/ftp-users"
-CONFIG_FILE="env.list" # May need to modify config file name to reflect future changes in env file location/name
-SLEEP_DURATION=60
-# Change theses next two variables to set different permissions for files/directories
-# These were default from vsftpd so change accordingly if necessary
-FILE_PERMISSIONS=644
-DIRECTORY_PERMISSIONS=750
+# shellcheck source=users.sh
+source /usr/local/users.sh
 
-add_users() {
-  aws s3 cp s3://$CONFIG_BUCKET/$CONFIG_FILE ~/$CONFIG_FILE
-  USERS=$(cat ~/"$CONFIG_FILE" | grep USERS | cut -d '=' -f2)
+CONFIG_FILE="${CONFIG_FILE:-env.list}"
+SLEEP_DURATION="${SLEEP_DURATION:-60}"
 
-  for u in $USERS; do
-    read username passwd <<< $(echo $u | sed 's/:/ /g')
+# Download the config file and provision every user it lists.
+reconcile_users() {
+  local tmp
+  tmp="$(mktemp)"
+  if ! aws s3 cp "s3://$CONFIG_BUCKET/$CONFIG_FILE" "$tmp" >/dev/null 2>&1; then
+    log "Could not download s3://$CONFIG_BUCKET/$CONFIG_FILE; skipping this cycle"
+    rm -f "$tmp"
+    return 0
+  fi
 
-    # If account exists set password again
-    # In cases where password changes in env file
-    if getent passwd "$username" >/dev/null 2>&1; then
-      echo $u | chpasswd -e
+  local users_line
+  users_line="$(grep -E '^USERS=' "$tmp" | head -n1 | cut -d= -f2- || true)"
+  rm -f "$tmp"
 
-      # Fix for issue when pulling files that were uploaded directly to S3 (through aws web console)
-      # Permissions when uploaded directly through S3 Web client were set as:
-      # 000 root:root
-      # This would not allow ftp users to read the files
-
-      # Search for files and directories not owned correctly
-      find "$FTP_DIRECTORY/$username/files/" -mindepth 1 \( \! -user "$username" \! -group "$username" \) -print0 | xargs -0 -r chown "$username:$username"
-
-      # Search for files with incorrect permissions
-      find "$FTP_DIRECTORY/$username/files/" -mindepth 1 -type f \! -perm "$FILE_PERMISSIONS" -print0 | xargs -0 -r chmod "$FILE_PERMISSIONS"
-
-      # Search for directories with incorrect permissions
-      find "$FTP_DIRECTORY/$username/files/" -mindepth 1 -type d \! -perm "$DIRECTORY_PERMISSIONS" -print0 | xargs -0 -r chmod "$DIRECTORY_PERMISSIONS"
-
-      # Search for .ssh folders and authorized_keys files with incorrect permissions/ownership
-      find "$FTP_DIRECTORY/$username/.ssh" -mindepth 1 -type d \! -perm 700 -print0 | xargs -0 -r chmod 700
-      find "$FTP_DIRECTORY/$username/.ssh" -mindepth 1 -type d \! -user "$username" -print0 | xargs -0 -r chown "$username"
-
-      find "$FTP_DIRECTORY/$username/.ssh/authorized_keys" -mindepth 1 -type f \! -perm 600 -print0 | xargs -0 -r chmod 600
-      find "$FTP_DIRECTORY/$username/.ssh/authorized_keys" -mindepth 1 -type f \! -user "$username" -print0 | xargs -0 -r chown "$username"
-    fi
-
-    # If user account doesn't exist create it
-    if ! getent passwd "$username" >/dev/null 2>&1; then
-      useradd -d "$FTP_DIRECTORY/$username" -s /usr/sbin/nologin $username
-      usermod -G ftpaccess $username
-
-      mkdir -p "$FTP_DIRECTORY/$username"
-      chown root:ftpaccess "$FTP_DIRECTORY/$username"
-      chmod 750 "$FTP_DIRECTORY/$username"
-
-      mkdir -p "$FTP_DIRECTORY/$username/files"
-      chown $username:ftpaccess "$FTP_DIRECTORY/$username/files"
-      chmod 750 "$FTP_DIRECTORY/$username/files"
-    fi
+  local entry username passwd
+  # shellcheck disable=SC2086 # intentional word-splitting on the USERS string
+  for entry in $users_line; do
+    username="${entry%%:*}"
+    passwd="${entry#*:}"
+    provision_user "$username" "$passwd" || log "Failed to provision '$username'"
+    fix_user_permissions "$username" || log "Failed to fix permissions for '$username'"
   done
 }
 
+if [[ -z "${CONFIG_BUCKET:-}" ]]; then
+  log "CONFIG_BUCKET is not set; live user reload is disabled."
+  # Stay alive (supervised) without busy-looping.
+  exec sleep infinity
+fi
+
+ensure_base
 while true; do
-  add_users
-  sleep $SLEEP_DURATION
+  reconcile_users || log "Reconcile cycle failed; will retry"
+  sleep "$SLEEP_DURATION"
 done

--- a/s3-fuse.sh
+++ b/s3-fuse.sh
@@ -1,55 +1,80 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Mounts the S3 bucket with s3fs, configures vsftpd's passive address and runs
+# the initial user provisioning.
+set -euo pipefail
 
-# Check first if the required FTP_BUCKET variable was provided, if not, abort.
-if [ -z $FTP_BUCKET ]; then
-  echo "You need to set BUCKET environment variable. Aborting!"
-  exit 1
+MOUNT_POINT="${MOUNT_POINT:-/home/aws/s3bucket}"
+VSFTPD_CONF="${VSFTPD_CONF:-/etc/vsftpd.conf}"
+
+log() { printf '[s3-fuse] %s\n' "$*"; }
+die() { log "$*"; exit 1; }
+
+# --- required configuration -------------------------------------------------
+[[ -n "${FTP_BUCKET:-}" ]] || die "FTP_BUCKET is not set. Aborting!"
+
+# Either an IAM role or a static AWS credential pair must be provided. When
+# there is no IAM role, write the credentials to the s3fs password file.
+if [[ -z "${IAM_ROLE:-}" ]]; then
+  log "IAM_ROLE not set; expecting AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY."
+  [[ -n "${AWS_ACCESS_KEY_ID:-}" ]] || die "AWS_ACCESS_KEY_ID is not set. Aborting!"
+  [[ -n "${AWS_SECRET_ACCESS_KEY:-}" ]] || die "AWS_SECRET_ACCESS_KEY is not set. Aborting!"
+
+  umask 077
+  printf '%s:%s\n' "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" > "$HOME/.passwd-s3fs"
+  chmod 600 "$HOME/.passwd-s3fs"
 fi
 
-# Then check if there is an IAM_ROLE provided, if not, check if the AWS credentials were provided.
-if [ -z $IAM_ROLE ]; then
-  echo "You did not set an IAM_ROLE environment variable. Checking if AWS access keys where provided ..."
+# --- passive-mode address ---------------------------------------------------
+
+# Query the EC2 Instance Metadata Service (IMDSv2, falling back to IMDSv1) for
+# the instance's public IPv4 address. Prints the address on success.
+detect_ec2_public_ip() {
+  local imds="http://169.254.169.254" token ip
+  local -a auth=()
+  token="$(curl -s --max-time 2 -X PUT "$imds/latest/api/token" \
+    -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' 2>/dev/null || true)"
+  [[ -n "$token" ]] && auth=(-H "X-aws-ec2-metadata-token: $token")
+  ip="$(curl -s --max-time 2 "${auth[@]}" "$imds/latest/meta-data/public-ipv4" 2>/dev/null || true)"
+  [[ -n "$ip" ]] || return 1
+  printf '%s' "$ip"
+}
+
+configure_pasv_address() {
+  local ip
+  if [[ -n "${PASV_ADDRESS:-}" ]]; then
+    ip="$PASV_ADDRESS"
+  elif ip="$(detect_ec2_public_ip)"; then
+    log "Detected EC2 public IPv4: $ip"
+  else
+    die "PASV_ADDRESS is not set and EC2 metadata is unavailable. Aborting!"
+  fi
+  sed -i "s/^pasv_address=.*/pasv_address=$ip/" "$VSFTPD_CONF"
+}
+
+configure_pasv_address
+
+# --- mount ------------------------------------------------------------------
+mkdir -p "$MOUNT_POINT"
+
+# -o nonempty lets s3fs mount over a directory that is not empty (see issue #1).
+s3fs_opts=(
+  -o allow_other
+  -o mp_umask=0022
+  -o nonempty
+  -o stat_cache_expire=600
+)
+[[ -n "${IAM_ROLE:-}" ]] && s3fs_opts+=(-o iam_role="$IAM_ROLE")
+
+log "Mounting s3://$FTP_BUCKET at $MOUNT_POINT"
+# s3fs is resolved from PATH (/usr/bin or /usr/local/bin depending on the build).
+if ! s3fs "$FTP_BUCKET" "$MOUNT_POINT" "${s3fs_opts[@]}"; then
+  die "s3fs failed to mount '$FTP_BUCKET'. Aborting!"
 fi
 
-# Abort if the AWS_ACCESS_KEY_ID was not provided if an IAM_ROLE was not provided neither.
-if [ -z $IAM_ROLE ] &&  [ -z $AWS_ACCESS_KEY_ID ]; then
-  echo "You need to set AWS_ACCESS_KEY_ID environment variable. Aborting!"
-  exit 1
+if command -v mountpoint >/dev/null 2>&1 && ! mountpoint -q "$MOUNT_POINT"; then
+  die "'$MOUNT_POINT' is not mounted after s3fs. Aborting!"
 fi
 
-# Abort if the AWS_SECRET_ACCESS_KEY was not provided if an IAM_ROLE was not provided neither.
-if [ -z $IAM_ROLE ] && [ -z $AWS_SECRET_ACCESS_KEY ]; then
-  echo "You need to set AWS_SECRET_ACCESS_KEY environment variable. Aborting!"
-  exit 1
-fi
-
-# If there is no IAM_ROLE but the AWS credentials were provided, then set them as the s3fs credentials.
-if [ -z $IAM_ROLE ] && [ ! -z $AWS_ACCESS_KEY_ID ] && [ ! -z $AWS_SECRET_ACCESS_KEY ]; then
-  #set the aws access credentials from environment variables
-  echo $AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY > ~/.passwd-s3fs
-  chmod 600 ~/.passwd-s3fs
-fi
-
-if [ ! -z $PASV_ADDRESS ]; then
-  sed -i "s/^pasv_address=/pasv_address=$PASV_ADDRESS/" /etc/vsftpd.conf
-elif curl -s http://instance-data > /dev/null ; then
-  IP=$(curl -s http://instance-data/latest/meta-data/public-ipv4)
-  sed -i "s/^pasv_address=/pasv_address=$IP/" /etc/vsftpd.conf
-else
-  echo "You need to set PASV_ADDRESS environment variable, or run in an EC2 instance. Aborting!"
-  exit 1
-fi
-
-# Update the vsftpd.conf file to include the IP address if running on an EC2 instance
-# if curl -s http://instance-data.ec2.internal > /dev/null ; then
-#   IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
-#   sed -i "s/^pasv_address=/pasv_address=$IP/" /etc/vsftpd.conf
-# else
-#   echo "Skipping"
-# fi
-
-# start s3 fuse
-# Code above is not needed if the IAM role is attaced to EC2 instance
-# s3fs provides the iam_role option to grab those credentials automatically
-/usr/local/bin/s3fs $FTP_BUCKET /home/aws/s3bucket -o allow_other -o mp_umask="0022" -o iam_role="$IAM_ROLE" -o stat_cache_expire=600 #-d -d -f -o f2 -o curldbg
+# Initial user provisioning.
 /usr/local/users.sh

--- a/users.sh
+++ b/users.sh
@@ -1,60 +1,109 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# User provisioning for the FTP/SFTP server.
+#
+# This file doubles as a library: when sourced it only defines functions, and
+# when executed directly it performs the initial provisioning from the USERS
+# environment variable. add_users_in_container.sh sources it to reuse the same
+# logic for the live-reload loop, so the account-management code lives in one
+# place.
+set -euo pipefail
 
-FTP_DIRECTORY="/home/aws/s3bucket/ftp-users"
+FTP_DIRECTORY="${FTP_DIRECTORY:-/home/aws/s3bucket/ftp-users}"
+FTP_GROUP="${FTP_GROUP:-ftpaccess}"
+# Permissions used both when creating users and when repairing files that were
+# uploaded to the bucket directly (e.g. via the AWS console).
+FILE_PERMISSIONS="${FILE_PERMISSIONS:-644}"
+DIRECTORY_PERMISSIONS="${DIRECTORY_PERMISSIONS:-750}"
 
-# Create a group for ftp users
-groupadd ftpaccess
+log() { printf '[users] %s\n' "$*"; }
 
+# Create the shared group and the parent directory for all user homes.
+ensure_base() {
+  if ! getent group "$FTP_GROUP" >/dev/null 2>&1; then
+    groupadd "$FTP_GROUP"
+  fi
+  mkdir -p "$FTP_DIRECTORY"
+  chown root:root "$FTP_DIRECTORY"
+  chmod 755 "$FTP_DIRECTORY"
+}
 
-# Create a directory where all ftp/sftp users home directories will go
-mkdir -p $FTP_DIRECTORY
-chown root:root $FTP_DIRECTORY
-chmod 755 $FTP_DIRECTORY
-
-# Expecing an environment variable called USERS to look like "bob:hashedbobspassword steve:hashedstevespassword"
-for u in $USERS; do
-
-  read username passwd <<< $(echo $u | sed 's/:/ /g')
-
-  # User needs to be created every time since stopping the docker container gets rid of users.
-  useradd -d "$FTP_DIRECTORY/$username" -s /usr/sbin/nologin $username
-  usermod -G ftpaccess $username
-
-  # set the users password
-  echo $u | chpasswd -e
-
-  if [ -z "$username" ] || [ -z "$passwd" ]; then
-    echo "Invalid username:password combination '$u': please fix to create '$username'"
-    continue
-  elif [ -d "$FTP_DIRECTORY/$username" ]; then
-    echo "Skipping creation of '$username' directory: already exists"
-
-    # Directory exists but permissions for it have to be setup anyway.
-    chown root:ftpaccess "$FTP_DIRECTORY/$username"
-    chmod 750 "$FTP_DIRECTORY/$username"
-    chown $username:ftpaccess "$FTP_DIRECTORY/$username/files"
-    chmod 750 "$FTP_DIRECTORY/$username/files"
-
-    # Create .ssh folder and authorized_keys file, for ssh-key sftp access
-    mkdir -p "$FTP_DIRECTORY/$username/.ssh"
-    chmod 700 "$FTP_DIRECTORY/$username/.ssh"
-    chown $username "$FTP_DIRECTORY/$username/.ssh"
-    touch "$FTP_DIRECTORY/$username/.ssh/authorized_keys"
-    chmod 600 "$FTP_DIRECTORY/$username/.ssh/authorized_keys"
-    chown $username "$FTP_DIRECTORY/$username/.ssh/authorized_keys"
-
-  else
-    echo "Creating '$username' directory..."
-
-    # Root must own all directories leading up to and including users home directory
-    mkdir -p "$FTP_DIRECTORY/$username"
-    chown root:ftpaccess "$FTP_DIRECTORY/$username"
-    chmod 750 "$FTP_DIRECTORY/$username"
-
-    # Need files sub-directory for SFTP chroot
-    mkdir -p "$FTP_DIRECTORY/$username/files"
-    chown $username:ftpaccess "$FTP_DIRECTORY/$username/files"
-    chmod 750 "$FTP_DIRECTORY/$username/files"
+# provision_user <username> <password_hash>
+# Idempotently creates the account (if missing), (re)sets its password and lays
+# out the chrooted home directory, files/ area and .ssh/authorized_keys.
+provision_user() {
+  local username="$1" passwd="$2"
+  if [[ -z "$username" || -z "$passwd" ]]; then
+    log "Skipping invalid 'username:password' entry"
+    return 0
   fi
 
-done
+  local home="$FTP_DIRECTORY/$username"
+
+  if ! getent passwd "$username" >/dev/null 2>&1; then
+    log "Creating user '$username'"
+    useradd -d "$home" -s /usr/sbin/nologin "$username"
+  fi
+  usermod -aG "$FTP_GROUP" "$username"
+
+  # Passwords are provided pre-hashed (chpasswd -e).
+  printf '%s:%s\n' "$username" "$passwd" | chpasswd -e
+
+  # Root must own the chroot target; the writable area is files/.
+  mkdir -p "$home/files"
+  chown "root:$FTP_GROUP" "$home"
+  chmod 750 "$home"
+  chown "$username:$FTP_GROUP" "$home/files"
+  chmod 750 "$home/files"
+
+  # .ssh/authorized_keys for public-key SFTP access.
+  mkdir -p "$home/.ssh"
+  touch "$home/.ssh/authorized_keys"
+  chown -R "$username" "$home/.ssh"
+  chmod 700 "$home/.ssh"
+  chmod 600 "$home/.ssh/authorized_keys"
+}
+
+# fix_user_permissions <username>
+# Repairs ownership/permissions on a user's files. Objects uploaded straight to
+# S3 (e.g. through the console) appear as 000 root:root and are unreadable over
+# FTP; this brings them back in line.
+fix_user_permissions() {
+  local username="$1"
+  local files="$FTP_DIRECTORY/$username/files"
+  local ssh="$FTP_DIRECTORY/$username/.ssh"
+
+  [[ -d "$files" ]] || return 0
+
+  find "$files/" -mindepth 1 \( ! -user "$username" -o ! -group "$username" \) \
+    -print0 | xargs -0 -r chown "$username:$username"
+  find "$files/" -mindepth 1 -type f ! -perm "$FILE_PERMISSIONS" \
+    -print0 | xargs -0 -r chmod "$FILE_PERMISSIONS"
+  find "$files/" -mindepth 1 -type d ! -perm "$DIRECTORY_PERMISSIONS" \
+    -print0 | xargs -0 -r chmod "$DIRECTORY_PERMISSIONS"
+
+  if [[ -d "$ssh" ]]; then
+    chown -R "$username" "$ssh"
+    chmod 700 "$ssh"
+    [[ -f "$ssh/authorized_keys" ]] && chmod 600 "$ssh/authorized_keys"
+  fi
+}
+
+# provision_users_from_string "<user:hash user2:hash2 ...>"
+# Splits a USERS-style string on whitespace and provisions each entry. The
+# username is everything before the first ':' and the hash everything after it.
+provision_users_from_string() {
+  local entry username passwd
+  # shellcheck disable=SC2086 # intentional word-splitting on the USERS string
+  for entry in $1; do
+    username="${entry%%:*}"
+    passwd="${entry#*:}"
+    provision_user "$username" "$passwd" || log "Failed to provision '$username'"
+  done
+}
+
+# When run directly, perform the one-shot initial provisioning.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  ensure_base
+  provision_users_from_string "${USERS:-}"
+fi


### PR DESCRIPTION
## Summary
Hardens the three shell scripts and fixes the issues reported in #1.

## Reliability & safety
- `set -euo pipefail`, quoted variables and explicit error handling in all three scripts.
- The s3fs mount is now checked: a failed mount aborts instead of silently starting vsftpd over an empty directory, and the mount point is verified with `mountpoint`.
- `aws s3 cp` failures in the live-reload loop are caught — a transient failure skips the cycle instead of killing the daemon.
- When `CONFIG_BUCKET` is unset the loop no longer fails every 60s; it disables itself cleanly.

## Fixes for #1
- **Mount over a non-empty directory:** s3fs is mounted with `-o nonempty`.
- The AppArmor side of #1 (`--security-opt apparmor:unconfined`) is documented in the README/compose (docs PR).

## Correctness
- **EC2 metadata:** the old `http://instance-data` lookup never worked; replaced with the real IMDS endpoint `169.254.169.254` using **IMDSv2** (token) with an IMDSv1 fallback.
- `s3fs` is resolved from `PATH`, so the scripts work whether it lives in `/usr/bin` (distro package) or `/usr/local/bin` (source build).
- `user:hash` is parsed with parameter expansion, which handles crypt hashes robustly.

## De-duplication
`users.sh` and `add_users_in_container.sh` contained ~40 lines of near-identical account logic. `users.sh` is now a sourceable library exposing `provision_user`, `fix_user_permissions` and `ensure_base`; it provisions from `USERS` only when executed directly, and the live-reload loop sources it.

## Validation
- `bash -n` clean on all three scripts.
- `shellcheck` (koalaman/shellcheck:stable, `-e SC1091`) passes with no findings.
- Provisioning + parsing exercised with stubbed `useradd`/`getent`/… confirming correct directory layout, password parsing (`$1$…`, `$6$…`) and that sourcing the library does not trigger provisioning.

Closes #1.
