### PR TITLE
Make process supervision reliable and container-friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
  && echo "/usr/sbin/nologin" >> /etc/shells
 
 # Application scripts
-COPY ["s3-fuse.sh", "users.sh", "add_users_in_container.sh", "/usr/local/"]
-RUN chmod +x /usr/local/s3-fuse.sh /usr/local/users.sh /usr/local/add_users_in_container.sh
+COPY ["s3-fuse.sh", "start-vsftpd.sh", "users.sh", "add_users_in_container.sh", "/usr/local/"]
+RUN chmod +x /usr/local/s3-fuse.sh /usr/local/start-vsftpd.sh /usr/local/users.sh /usr/local/add_users_in_container.sh
 
 # Service configuration
 COPY vsftpd.conf /etc/vsftpd.conf

--- a/s3-fuse.sh
+++ b/s3-fuse.sh
@@ -8,7 +8,15 @@ MOUNT_POINT="${MOUNT_POINT:-/home/aws/s3bucket}"
 VSFTPD_CONF="${VSFTPD_CONF:-/etc/vsftpd.conf}"
 
 log() { printf '[s3-fuse] %s\n' "$*"; }
-die() { log "$*"; exit 1; }
+
+# Fatal error: log, then bring the whole container down. Otherwise supervisord
+# would keep vsftpd running over an unmounted/empty directory. With
+# `--restart=always` the container then restarts and retries cleanly.
+die() {
+  log "$*"
+  supervisorctl shutdown >/dev/null 2>&1 || kill -s TERM 1 2>/dev/null || true
+  exit 1
+}
 
 # --- required configuration -------------------------------------------------
 [[ -n "${FTP_BUCKET:-}" ]] || die "FTP_BUCKET is not set. Aborting!"

--- a/start-vsftpd.sh
+++ b/start-vsftpd.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Waits for the S3 bucket to be mounted before starting vsftpd, so the server
+# never exposes the empty mount point while s3fs is still coming up.
+set -euo pipefail
+
+MOUNT_POINT="${MOUNT_POINT:-/home/aws/s3bucket}"
+VSFTPD_CONF="${VSFTPD_CONF:-/etc/vsftpd.conf}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-60}"
+
+log() { printf '[vsftpd] %s\n' "$*"; }
+
+for _ in $(seq 1 "$WAIT_TIMEOUT"); do
+  if mountpoint -q "$MOUNT_POINT"; then
+    log "Mount ready; starting vsftpd"
+    exec /usr/sbin/vsftpd "$VSFTPD_CONF"
+  fi
+  sleep 1
+done
+
+log "$MOUNT_POINT not mounted after ${WAIT_TIMEOUT}s; exiting so supervisor can retry"
+exit 1

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,21 +1,46 @@
 [supervisord]
 nodaemon=true
-logfile=/var/log/supervisord.log
+user=root
+logfile=/dev/null
+logfile_maxbytes=0
 
+# Control socket so a fatal failure (e.g. the S3 mount) can shut the whole
+# container down instead of leaving an FTP server running over an empty bucket.
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+# One-shot: mounts the bucket and provisions users, then exits 0. If it fails it
+# shuts supervisord down (see s3-fuse.sh), so the container exits and can be
+# restarted cleanly rather than serving an empty mount point.
 [program:s3-fuse]
 command=/usr/local/s3-fuse.sh
 autorestart=false
+startsecs=0
 priority=1
-stdout_logfile=/var/log/s3-fuse-startup.log
-stderr_logfile=/var/log/s3-fuse-startup.log
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 
+# Waits for the S3 mount to be ready before serving (start-vsftpd.sh).
 [program:vsftpd]
-command=/usr/sbin/vsftpd
+command=/usr/local/start-vsftpd.sh
 autorestart=true
+priority=20
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:add_users_in_container]
 command=/usr/local/add_users_in_container.sh
 autorestart=true
-stdout_logfile=/var/log/add-users.log
-stderr_logfile=/var/log/add-users.log
-
+priority=30
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
## Summary
Fixes long-standing reliability problems in how the container supervises its processes.

## Problems addressed
1. **Logs were written to files** under `/var/log` inside the container, so `docker logs` showed nothing useful and the logs could grow unbounded.
2. **Startup race:** `vsftpd` and the reconcile loop started at the same time as `s3-fuse.sh`, so vsftpd could begin serving the mount point *before* s3fs had mounted the bucket.
3. **Silent failure:** if the S3 mount (or required config) failed, `s3-fuse` just exited while `vsftpd` kept running, serving an **empty** directory with no users — a confusing, hard-to-detect state.

## Changes
- All programs log to the container's **stdout** (`/dev/fd/1`, `maxbytes=0`).
- Added a supervisor control socket; `s3-fuse.sh`'s `die()` now calls `supervisorctl shutdown` (falling back to `kill -TERM 1`) so a fatal error **brings the whole container down**. With `--restart=always` it restarts and retries cleanly instead of lingering in a broken state.
- `vsftpd` now starts via **`start-vsftpd.sh`**, which waits (up to `WAIT_TIMEOUT`, default 60s) for the mount to be ready before `exec`-ing vsftpd.
- Explicit program **priorities**: mount (1) → serve (20) → reconcile (30).

## Validation
- `shellcheck` clean on `start-vsftpd.sh` and `s3-fuse.sh`; supervisord config parses.
- `docker build` succeeds and ships `start-vsftpd.sh`.
- **End-to-end:** ran the image with `FTP_BUCKET` unset — `s3-fuse` logs the error, calls `supervisorctl shutdown`, supervisord stops all programs, and the container exits cleanly (no hang). Confirmed `mountpoint`/`vsftpd`/`s3fs`/`supervisorctl` are all present in the image.
