### PR TITLE
Add bats test suite for the user-provisioning library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,16 @@ jobs:
         with:
           dockerfile: Dockerfile
 
+  test:
+    name: Bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run tests
+        run: bats tests/
+
   build:
     name: Build image
     runs-on: ubuntu-latest

--- a/tests/stubs/chmod
+++ b/tests/stubs/chmod
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "$(basename "$0") $*" >> "$STUB_LOG"
+exit 0

--- a/tests/stubs/chown
+++ b/tests/stubs/chown
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "$(basename "$0") $*" >> "$STUB_LOG"
+exit 0

--- a/tests/stubs/chpasswd
+++ b/tests/stubs/chpasswd
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+input="$(cat)"
+echo "chpasswd $* <<< $input" >> "$STUB_LOG"
+exit 0

--- a/tests/stubs/getent
+++ b/tests/stubs/getent
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+echo "getent $*" >> "$STUB_LOG"
+db="${1:-}"; key="${2:-}"
+case "$db" in
+  group)  case " ${STUB_EXISTING_GROUPS:-} " in *" $key "*) exit 0;; esac ;;
+  passwd) case " ${STUB_EXISTING_USERS:-} "  in *" $key "*) exit 0;; esac ;;
+esac
+exit 2

--- a/tests/stubs/groupadd
+++ b/tests/stubs/groupadd
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "$(basename "$0") $*" >> "$STUB_LOG"
+exit 0

--- a/tests/stubs/useradd
+++ b/tests/stubs/useradd
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "$(basename "$0") $*" >> "$STUB_LOG"
+exit 0

--- a/tests/stubs/usermod
+++ b/tests/stubs/usermod
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "$(basename "$0") $*" >> "$STUB_LOG"
+exit 0

--- a/tests/users.bats
+++ b/tests/users.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the user-provisioning library (users.sh). System commands
+# (useradd, getent, chpasswd, ...) are replaced by recording stubs in
+# tests/stubs so the logic can be exercised without root or real accounts.
+
+setup() {
+  TESTDIR="$(mktemp -d)"
+  export STUB_LOG="$TESTDIR/calls.log"
+  : > "$STUB_LOG"
+  export FTP_DIRECTORY="$TESTDIR/ftp-users"
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # shellcheck source=../users.sh
+  source "$BATS_TEST_DIRNAME/../users.sh"
+}
+
+teardown() {
+  rm -rf "$TESTDIR"
+}
+
+@test "ensure_base creates the base directory and group" {
+  ensure_base
+  [ -d "$FTP_DIRECTORY" ]
+  grep -q "groupadd ftpaccess" "$STUB_LOG"
+}
+
+@test "ensure_base does not recreate an existing group" {
+  STUB_EXISTING_GROUPS="ftpaccess" ensure_base
+  ! grep -q "groupadd" "$STUB_LOG"
+}
+
+@test "provision_user creates a new account and home layout" {
+  provision_user alice '$1$salt$hashA'
+  grep -q "useradd -d $FTP_DIRECTORY/alice -s /usr/sbin/nologin alice" "$STUB_LOG"
+  grep -q "usermod -aG ftpaccess alice" "$STUB_LOG"
+  [ -d "$FTP_DIRECTORY/alice/files" ]
+  [ -d "$FTP_DIRECTORY/alice/.ssh" ]
+  [ -f "$FTP_DIRECTORY/alice/.ssh/authorized_keys" ]
+}
+
+@test "provision_user sets the (pre-hashed) password" {
+  provision_user bob '$6$salt$hashB'
+  grep -Fq 'chpasswd -e <<< bob:$6$salt$hashB' "$STUB_LOG"
+}
+
+@test "provision_user updates an existing account without useradd" {
+  STUB_EXISTING_USERS="carol" provision_user carol '$1$s$h'
+  ! grep -q "useradd" "$STUB_LOG"
+  grep -Fq 'chpasswd -e <<< carol:$1$s$h' "$STUB_LOG"
+}
+
+@test "provision_user skips entries with an empty password" {
+  provision_user dave ""
+  ! grep -q "useradd" "$STUB_LOG"
+  ! grep -q "chpasswd" "$STUB_LOG"
+}
+
+@test "provision_users_from_string provisions every entry and keeps hashes intact" {
+  provision_users_from_string 'eve:$1$a$h1 frank:$6$b$h2'
+  grep -q "useradd -d $FTP_DIRECTORY/eve " "$STUB_LOG"
+  grep -q "useradd -d $FTP_DIRECTORY/frank " "$STUB_LOG"
+  grep -Fq 'chpasswd -e <<< eve:$1$a$h1' "$STUB_LOG"
+  grep -Fq 'chpasswd -e <<< frank:$6$b$h2' "$STUB_LOG"
+}
+
+@test "fix_user_permissions is a no-op when the files dir is missing" {
+  run fix_user_permissions ghost
+  [ "$status" -eq 0 ]
+  ! grep -q "chown" "$STUB_LOG"
+}
+
+@test "fix_user_permissions repairs ownership of S3-uploaded files" {
+  # 'daemon' is a stock account on Debian/Ubuntu; fix_user_permissions uses
+  # find -user/-group, which require the name to resolve in the OS passwd db
+  # (in production the FTP user always exists by the time this runs).
+  mkdir -p "$FTP_DIRECTORY/daemon/files"
+  echo data > "$FTP_DIRECTORY/daemon/files/object.txt"
+  fix_user_permissions daemon
+  grep -q "chown daemon:daemon" "$STUB_LOG"
+}
+
+@test "sourcing users.sh defines functions but does not provision" {
+  # setup already sourced the library; provisioning must not have run on source.
+  ! grep -q "useradd" "$STUB_LOG"
+  declare -F provision_user >/dev/null
+  declare -F fix_user_permissions >/dev/null
+  declare -F ensure_base >/dev/null
+}
+
+@test "running users.sh directly provisions from USERS" {
+  run env USERS='ivan:$1$x$y' FTP_DIRECTORY="$FTP_DIRECTORY" \
+    STUB_LOG="$STUB_LOG" PATH="$BATS_TEST_DIRNAME/stubs:$PATH" \
+    bash "$BATS_TEST_DIRNAME/../users.sh"
+  [ "$status" -eq 0 ]
+  grep -q "useradd -d $FTP_DIRECTORY/ivan " "$STUB_LOG"
+}


### PR DESCRIPTION
## Summary
Adds the project's first automated tests and runs them in CI, so the script logic that was previously only hand-verified is now protected against regressions.

## What's covered
`tests/users.bats` exercises the `users.sh` library with system commands replaced by **recording stubs** (`tests/stubs/`), so it runs without root or real accounts:

- `provision_user` — new-account creation + home/`.ssh` layout, **password update path for an existing account** (no second `useradd`), pre-hashed password passed to `chpasswd -e`, and skipping entries with an empty password.
- `provision_users_from_string` — provisions every entry and keeps crypt hashes (`$1$…`, `$6$…`) intact through the parse.
- `fix_user_permissions` — no-op when the files dir is missing; repairs ownership otherwise.
- The **library guard** — sourcing `users.sh` defines functions without provisioning; running it directly provisions from `USERS`.

## CI
A `Bats tests` job installs `bats` and runs `bats tests/` on every PR.

## Validation
All 11 tests pass locally (run in a clean `debian:bookworm-slim` container to match the CI toolchain); stubs are shellcheck-clean.
