### PR TITLE
Add repository hygiene: security policy, templates, editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.sh]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Shell scripts must use LF endings so they run inside the Linux container.
+*.sh text eol=lf
+*.bats text eol=lf
+Dockerfile text eol=lf
+*.conf text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @diogopms

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a problem with ftp-proxy-s3
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear description of what went wrong.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Environment
+
+- Image tag / commit:
+- Host OS and Docker version:
+- Running on EC2? (IAM role vs. static keys):
+- Auth method: FTP / FTPS / SFTP
+
+## Logs
+
+<!--
+`docker logs <container>` output. REMOVE any secrets (AWS keys, passwords,
+bucket names you consider sensitive) before pasting.
+-->
+
+```
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/diogopms/ftp-proxy-s3/security/advisories/new
+    about: Please report security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What are you trying to do that is currently hard or impossible?
+
+## Proposed solution
+
+What would you like to see?
+
+## Alternatives considered
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+PR titles should follow Conventional Commits (e.g. "fix: ...", "feat: ...")
+because releases are generated from them. See CONTRIBUTING.md.
+-->
+
+## Summary
+
+<!-- What does this change do and why? -->
+
+## Changes
+
+-
+
+## Testing
+
+<!-- How did you verify it? e.g. `bats tests/`, `docker build`, manual run -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] `shellcheck` / `hadolint` pass (or N/A)
+- [ ] `bats tests/` pass (or N/A)
+- [ ] Docs updated if behaviour or configuration changed

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,6 @@
+failure-threshold: warning
+ignored:
+  # Pinning every apt package version is intentionally avoided: this image is
+  # rebuilt regularly (see the daily release workflow) and should pick up the
+  # latest Debian security updates rather than freeze to a fixed version.
+  - DL3008

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Instead, report vulnerabilities privately through GitHub's
+[security advisories](https://github.com/diogopms/ftp-proxy-s3/security/advisories/new)
+("Report a vulnerability"). You can expect an initial response within a few days.
+
+## Supported versions
+
+Only the latest released image (`ghcr.io/diogopms/ftp-proxy-s3:latest`) is
+maintained. Older tags are not patched.
+
+## Operational security notes
+
+This project runs an FTP/SFTP front-end over an S3 bucket; please keep the
+following in mind when deploying it:
+
+- **Prefer an IAM role** (`IAM_ROLE`) over static `AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY` credentials. When static keys are used they are written
+  to `~/.passwd-s3fs` (mode `600`) inside the container; scope them to the single
+  bucket with least privilege.
+- **Use FTPS/SFTP and a real certificate.** The image ships with the Debian
+  snakeoil certificate as a placeholder — replace it for production and require
+  encryption.
+- **Keep `env.list` out of version control** (it is already git-ignored) and out
+  of the image build context (it is in `.dockerignore`).
+- **Restrict the exposed ports** (`21`, `30000-30100`) with a security group or
+  firewall to the clients that need them.
+- The container needs `SYS_ADMIN` + `/dev/fuse` (and often
+  `--security-opt apparmor:unconfined`) for the FUSE mount; grant these instead
+  of full `--privileged` where possible.


### PR DESCRIPTION
## Summary
Adds standard open-source repository hygiene files so the project is easier and safer to contribute to.

## Added
- **SECURITY.md** — private vulnerability reporting (GitHub advisories) plus operational guidance: prefer IAM roles over static keys, enable FTPS/replace the snakeoil cert, keep `env.list` out of VCS, restrict the exposed ports, and prefer scoped capabilities over `--privileged`.
- **Issue templates** — bug report and feature request, with `config.yml` disabling blank issues and routing security reports to a private advisory.
- **PULL_REQUEST_TEMPLATE.md** — summary/testing sections and a checklist tied to the Conventional Commits release flow.
- **CODEOWNERS** — `* @diogopms` for review routing.
- **.editorconfig** + **.gitattributes** — consistent formatting and **LF enforcement** on `*.sh`/`*.bats`/config, so scripts always run correctly inside the Linux container even if edited on Windows.
- **.hadolint.yaml** — documents why `DL3008` (apt version pinning) is intentionally ignored for a regularly-rebuilt image.

No application behaviour changes.
