### PR TITLE
Enable opt-in FTPS and ship the TLS certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
       curl \
       fuse \
       s3fs \
+      ssl-cert \
       supervisor \
       vsftpd \
  && rm -rf /var/lib/apt/lists/* \

--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ docker build -t ftp-proxy-s3 .
 The image is based on `debian:bookworm-slim` and installs `s3fs`, `vsftpd`,
 `supervisor` and `awscli` from the Debian repositories.
 
+## Encryption (FTPS)
+
+The server offers **FTPS** (explicit TLS over FTP) but does not require it, so
+existing plain-FTP and SFTP clients keep working. The image ships a self-signed
+"snakeoil" certificate as a placeholder.
+
+- **Use a real certificate** in production by bind-mounting it over the defaults:
+  ```bash
+  -v /path/fullchain.pem:/etc/ssl/certs/ssl-cert-snakeoil.pem:ro \
+  -v /path/privkey.pem:/etc/ssl/private/ssl-cert-snakeoil.key:ro
+  ```
+- **To require encryption**, set `force_local_logins_ssl=YES` and
+  `force_local_data_ssl=YES` in `vsftpd.conf` and rebuild.
+
 ## Troubleshooting
 
 - **`s3fs` fails to mount / container exits immediately.** The host's AppArmor

--- a/vsftpd.conf
+++ b/vsftpd.conf
@@ -129,12 +129,28 @@ secure_chroot_dir=/home/aws/s3bucket/ftp-users
 # This string is the name of the PAM service vsftpd will use.
 pam_service_name=vsftpd
 
-# This option specifies the location of the RSA certificate to use for SSL
-# encrypted connections.
+# TLS / FTPS.
+# The image ships a self-signed "snakeoil" certificate as a placeholder.
+# For production, replace these two files with a real certificate/key
+# (e.g. bind-mount them over these paths) so clients can verify the server.
 rsa_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
-# This option specifies the location of the RSA key to use for SSL
-# encrypted connections.
 rsa_private_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+# Offer FTPS but do not force it, so existing plain-FTP clients keep working.
+# To require encryption, set the two force_*_ssl options below to YES.
+ssl_enable=YES
+allow_anon_ssl=NO
+force_local_logins_ssl=NO
+force_local_data_ssl=NO
+# Disable the obsolete SSLv2/SSLv3 protocols and prefer strong ciphers. vsftpd
+# 3.0.3 has no per-TLS-version toggle; the effective minimum (TLS 1.2 on Debian
+# bookworm) is enforced by the system-wide OpenSSL policy.
+ssl_sslv2=NO
+ssl_sslv3=NO
+require_ssl_reuse=NO
+ssl_ciphers=HIGH
+# Do not leak numeric uids/gids in directory listings.
+hide_ids=YES
 
 pasv_address=
 pasv_enable=Yes


### PR DESCRIPTION
## Summary
Enables **FTPS** and fixes a latent broken certificate reference.

## The bug
`vsftpd.conf` pointed `rsa_cert_file`/`rsa_private_key_file` at the Debian snakeoil certificate, but the **`ssl-cert` package was never installed**, so those files did not exist in the image. TLS was effectively unusable — turning `ssl_enable=YES` on would have made vsftpd fail to start.

## Changes
- **Install `ssl-cert`** so the self-signed snakeoil certificate/key are generated at build time.
- **Enable FTPS, opt-in:** `ssl_enable=YES` with `force_local_logins_ssl=NO` / `force_local_data_ssl=NO`, so existing **plain-FTP and SFTP clients keep working** while TLS-capable clients can use `AUTH TLS`.
- Disable `SSLv2`/`SSLv3`, `ssl_ciphers=HIGH`, `allow_anon_ssl=NO`, `hide_ids=YES`. (vsftpd 3.0.3 has no per-TLS-version toggle; the effective **TLS 1.2 minimum** comes from Debian bookworm's system-wide OpenSSL policy.)
- README: how to bind-mount a real certificate and how to *require* encryption.

## Validation
- Built the image; confirmed the snakeoil cert/key now exist.
- Started `vsftpd` with the new config **inside the image** and confirmed it runs cleanly (with `pasv_address` populated, as `s3-fuse.sh` does at runtime). While doing this I also found that an **empty `pasv_address=`** makes vsftpd exit 2 — harmless because the mount step always fills it before vsftpd starts, but worth noting.
- Verified each TLS option individually against vsftpd 3.0.3 (this is how I caught that `ssl_tlsv1_1`/`ssl_tlsv1_2` are unsupported and would abort startup).
