### PR TITLE
Add Makefile for common dev tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,19 @@ Thanks for taking the time to contribute!
 
 ## Development
 
-- The application is a set of Bash scripts plus `vsftpd`/`supervisord` config,
-  packaged in a Docker image.
-- Lint before pushing:
-  - `shellcheck *.sh`
-  - `hadolint Dockerfile`
-- Build to validate: `docker build -t ftp-proxy-s3 .`
+The application is a set of Bash scripts plus `vsftpd`/`supervisord` config,
+packaged in a Docker image. A `Makefile` wraps the common tasks (each runs in
+Docker, so the only requirement is Docker itself):
 
-CI runs ShellCheck, Hadolint, an image build and a Trivy scan on every pull
-request.
+```bash
+make help    # list targets
+make lint    # shellcheck + hadolint
+make test    # run the bats suite
+make build   # build the image
+```
+
+CI runs ShellCheck, Hadolint, the bats tests, an image build and a Trivy scan on
+every pull request.
 
 ## Commit messages — Conventional Commits
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+IMAGE ?= ftp-proxy-s3
+TAG   ?= dev
+SHELL_SCRIPTS := s3-fuse.sh start-vsftpd.sh users.sh add_users_in_container.sh
+
+.DEFAULT_GOAL := help
+.PHONY: help build lint shellcheck hadolint test up down clean
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the Docker image (override with IMAGE=/TAG=)
+	docker build -t $(IMAGE):$(TAG) .
+
+lint: shellcheck hadolint ## Run all linters
+
+shellcheck: ## Lint the shell scripts and test stubs
+	docker run --rm -v "$(CURDIR):/mnt" -e SHELLCHECK_OPTS="-e SC1091" \
+		koalaman/shellcheck:stable $(SHELL_SCRIPTS) tests/stubs/*
+
+hadolint: ## Lint the Dockerfile
+	docker run --rm -v "$(CURDIR):/repo" -w /repo hadolint/hadolint hadolint Dockerfile
+
+test: ## Run the bats test suite (in a clean Debian container)
+	docker run --rm -v "$(CURDIR):/code" -w /code debian:bookworm-slim \
+		bash -c 'apt-get update -qq && apt-get install -y -qq bats >/dev/null && bats tests/'
+
+up: ## Start the stack with docker compose (needs env.list)
+	docker compose up -d
+
+down: ## Stop the docker compose stack
+	docker compose down
+
+clean: ## Remove the locally built image
+	-docker rmi $(IMAGE):$(TAG)


### PR DESCRIPTION
## Summary
Adds a self-documenting `Makefile` wrapping the common development tasks, so contributors don't have to remember the Docker invocations (which previously lived only in CI and PR descriptions).

## Targets
| Target | Does |
| --- | --- |
| `make help` | List targets (default goal) |
| `make build` | Build the image (`IMAGE=`/`TAG=` overridable) |
| `make lint` | `shellcheck` + `hadolint` |
| `make test` | Run the bats suite |
| `make up` / `make down` | `docker compose` up/down |
| `make clean` | Remove the built image |

Every target runs inside Docker, so the only local prerequisite is Docker, and the commands match CI exactly. `CONTRIBUTING.md` now points at them.

## Validation
Ran `make help`, `make shellcheck`, `make hadolint` and `make test` locally — all pass (11/11 bats tests; hadolint picks up `.hadolint.yaml`).
