### PR TITLE
Build and publish multi-arch (amd64 + arm64) release images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,9 @@ jobs:
             type=semver,pattern={{major}},value=${{ needs.release.outputs.version }}
             type=raw,value=latest
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -80,6 +83,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
Publishes the release images for **both `linux/amd64` and `linux/arm64`**, so they run natively on Graviton / Apple Silicon as well as x86.

## Changes
- Add `docker/setup-qemu-action` to the release publish job.
- Build with `platforms: linux/amd64,linux/arm64` in `build-push-action`.

Only the **release** workflow is multi-arch; CI still builds a single-arch image with `load: true` (multi-platform images can't be loaded into the local daemon), which keeps PR feedback fast.

## Validation
Built the image for `linux/arm64` locally via QEMU emulation — all stages (including the `s3fs`/`vsftpd`/`awscli` apt install) complete successfully, confirming every dependency is available on arm64.
