### PR TITLE
build: pin base image by digest for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM debian:bookworm-slim
+# Pinned by digest for reproducible builds; Dependabot keeps the digest current.
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 
 LABEL maintainer="Diogo <info@diogoserrano.com>" \
       org.opencontainers.image.title="ftp-proxy-s3" \


### PR DESCRIPTION
## Summary
Pins `debian:bookworm-slim` to its content **digest** so every build uses a byte-identical base layer, instead of whatever the `bookworm-slim` tag happens to point at when the build runs.

## Why
Tag-based `FROM` is mutable — the same Dockerfile can produce different images over time. Digest pinning makes builds reproducible and makes base-image changes explicit (a Dependabot PR) rather than silent.

Dependabot already tracks the `docker` ecosystem and updates pinned digests, so this stays current automatically.

## Validation
`docker build` succeeds with the pinned digest; `hadolint` passes.