### PR TITLE
perf: drop awscli and read the config bucket via s3fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ LABEL maintainer="Diogo <info@diogoserrano.com>" \
 # (and its CVEs) from the final image.
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install --no-install-recommends -y \
-      awscli \
       ca-certificates \
       curl \
       fuse \

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ permissions, so public-key SFTP access can be used in addition to passwords.
 
 ## Live-reloading users
 
-If `CONFIG_BUCKET` is set, the container periodically downloads
-`s3://$CONFIG_BUCKET/env.list` and reconciles the user list — adding new users
-and updating passwords without a restart. It also repairs ownership/permissions
-on files that were uploaded to the bucket directly (e.g. through the S3 console),
+If `CONFIG_BUCKET` is set, the container mounts it read-only and periodically
+reads `env.list` from it, reconciling the user list — adding new users and
+updating passwords without a restart. It also repairs ownership/permissions on
+files that were uploaded to the bucket directly (e.g. through the S3 console),
 which would otherwise be unreadable by the FTP user.
 
 ## Building locally
@@ -130,8 +130,8 @@ which would otherwise be unreadable by the FTP user.
 docker build -t ftp-proxy-s3 .
 ```
 
-The image is based on `debian:bookworm-slim` and installs `s3fs`, `vsftpd`,
-`supervisor` and `awscli` from the Debian repositories.
+The image is based on `debian:bookworm-slim` and installs `s3fs`, `vsftpd` and
+`supervisor` from the Debian repositories.
 
 ## Encryption (FTPS)
 

--- a/add_users_in_container.sh
+++ b/add_users_in_container.sh
@@ -6,24 +6,23 @@
 set -euo pipefail
 
 # shellcheck source=users.sh
-source /usr/local/users.sh
+source "${USERS_LIB:-/usr/local/users.sh}"
 
+CONFIG_MOUNT="${CONFIG_MOUNT:-/home/aws/config}"
 CONFIG_FILE="${CONFIG_FILE:-env.list}"
+CONFIG_PATH="$CONFIG_MOUNT/$CONFIG_FILE"
 SLEEP_DURATION="${SLEEP_DURATION:-60}"
 
-# Download the config file and provision every user it lists.
+# Read the config file (mounted read-only from the config bucket by s3-fuse.sh)
+# and provision every user it lists.
 reconcile_users() {
-  local tmp
-  tmp="$(mktemp)"
-  if ! aws s3 cp "s3://$CONFIG_BUCKET/$CONFIG_FILE" "$tmp" >/dev/null 2>&1; then
-    log "Could not download s3://$CONFIG_BUCKET/$CONFIG_FILE; skipping this cycle"
-    rm -f "$tmp"
+  if [[ ! -r "$CONFIG_PATH" ]]; then
+    log "Config file $CONFIG_PATH is not readable yet; skipping this cycle"
     return 0
   fi
 
   local users_line
-  users_line="$(grep -E '^USERS=' "$tmp" | head -n1 | cut -d= -f2- || true)"
-  rm -f "$tmp"
+  users_line="$(grep -E '^USERS=' "$CONFIG_PATH" | head -n1 | cut -d= -f2- || true)"
 
   local entry username passwd
   # shellcheck disable=SC2086 # intentional word-splitting on the USERS string
@@ -35,14 +34,18 @@ reconcile_users() {
   done
 }
 
-if [[ -z "${CONFIG_BUCKET:-}" ]]; then
-  log "CONFIG_BUCKET is not set; live user reload is disabled."
-  # Stay alive (supervised) without busy-looping.
-  exec sleep infinity
-fi
+# The reconcile loop only runs when executed directly; sourcing this file (e.g.
+# from the test suite) just defines reconcile_users.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ -z "${CONFIG_BUCKET:-}" ]]; then
+    log "CONFIG_BUCKET is not set; live user reload is disabled."
+    # Stay alive (supervised) without busy-looping.
+    exec sleep infinity
+  fi
 
-ensure_base
-while true; do
-  reconcile_users || log "Reconcile cycle failed; will retry"
-  sleep "$SLEEP_DURATION"
-done
+  ensure_base
+  while true; do
+    reconcile_users || log "Reconcile cycle failed; will retry"
+    sleep "$SLEEP_DURATION"
+  done
+fi

--- a/s3-fuse.sh
+++ b/s3-fuse.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 MOUNT_POINT="${MOUNT_POINT:-/home/aws/s3bucket}"
+CONFIG_MOUNT="${CONFIG_MOUNT:-/home/aws/config}"
 VSFTPD_CONF="${VSFTPD_CONF:-/etc/vsftpd.conf}"
 
 log() { printf '[s3-fuse] %s\n' "$*"; }
@@ -82,6 +83,19 @@ fi
 
 if command -v mountpoint >/dev/null 2>&1 && ! mountpoint -q "$MOUNT_POINT"; then
   die "'$MOUNT_POINT' is not mounted after s3fs. Aborting!"
+fi
+
+# Mount the config bucket read-only (when configured) so the live-reload loop
+# can read env.list directly from the filesystem, without a separate AWS client.
+# A short stat-cache keeps it reasonably responsive to changes.
+if [[ -n "${CONFIG_BUCKET:-}" ]]; then
+  config_opts=(-o ro -o stat_cache_expire=30)
+  [[ -n "${IAM_ROLE:-}" ]] && config_opts+=(-o iam_role="$IAM_ROLE")
+  mkdir -p "$CONFIG_MOUNT"
+  log "Mounting s3://$CONFIG_BUCKET at $CONFIG_MOUNT (read-only)"
+  if ! s3fs "$CONFIG_BUCKET" "$CONFIG_MOUNT" "${config_opts[@]}"; then
+    die "s3fs failed to mount config bucket '$CONFIG_BUCKET'. Aborting!"
+  fi
 fi
 
 # Initial user provisioning.

--- a/tests/reconcile.bats
+++ b/tests/reconcile.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+#
+# Tests for the live-reload reconcile step in add_users_in_container.sh, which
+# reads the USERS list from the config file mounted by s3-fuse.sh. System
+# commands are replaced by the recording stubs in tests/stubs.
+
+setup() {
+  TESTDIR="$(mktemp -d)"
+  export STUB_LOG="$TESTDIR/calls.log"
+  : > "$STUB_LOG"
+  export FTP_DIRECTORY="$TESTDIR/ftp-users"
+  export CONFIG_MOUNT="$TESTDIR/config"
+  mkdir -p "$CONFIG_MOUNT"
+  export PATH="$BATS_TEST_DIRNAME/stubs:$PATH"
+  # Source the live-reload script as a library (the run-loop is guarded), with
+  # the user library pointed at the repo copy.
+  export USERS_LIB="$BATS_TEST_DIRNAME/../users.sh"
+  source "$BATS_TEST_DIRNAME/../add_users_in_container.sh"
+}
+
+teardown() {
+  rm -rf "$TESTDIR"
+}
+
+@test "reconcile_users provisions users listed in the mounted config file" {
+  printf 'USERS=alice:$1$a$h1 bob:$6$b$h2\nFTP_BUCKET=x\n' > "$CONFIG_MOUNT/env.list"
+  reconcile_users
+  grep -q "useradd -d $FTP_DIRECTORY/alice " "$STUB_LOG"
+  grep -q "useradd -d $FTP_DIRECTORY/bob " "$STUB_LOG"
+  grep -Fq 'chpasswd -e <<< bob:$6$b$h2' "$STUB_LOG"
+}
+
+@test "reconcile_users is a no-op when the config file is missing" {
+  run reconcile_users
+  [ "$status" -eq 0 ]
+  ! grep -q "useradd" "$STUB_LOG"
+}
+
+@test "reconcile_users ignores other keys in the config file" {
+  printf 'FTP_BUCKET=mybucket\nUSERS=carol:$1$c$h\nCONFIG_BUCKET=cfg\n' > "$CONFIG_MOUNT/env.list"
+  reconcile_users
+  grep -q "useradd -d $FTP_DIRECTORY/carol " "$STUB_LOG"
+  ! grep -q "mybucket" "$STUB_LOG"
+}
+
+@test "sourcing add_users_in_container.sh does not start the reconcile loop" {
+  # setup already sourced it; reconcile must not have run on source.
+  ! grep -q "useradd" "$STUB_LOG"
+  declare -F reconcile_users >/dev/null
+}


### PR DESCRIPTION
## Summary
Shrinks the image from **~492 MB to ~320 MB** (−35%) by removing `awscli` and its bundled Python runtime.

## How
The live-reload loop used `aws s3 cp` to fetch `env.list` — the only reason `awscli` was installed. Instead:
- `s3-fuse.sh` now mounts `CONFIG_BUCKET` **read-only** with s3fs (short `stat_cache_expire=30` for responsiveness), reusing the credentials/IAM role already configured for the main mount.
- `add_users_in_container.sh` reads `env.list` straight from that mount.
- `awscli` is dropped from the Dockerfile.

The user-facing `CONFIG_BUCKET` contract is unchanged.

## Testability
`add_users_in_container.sh` is now sourceable (overridable `USERS_LIB` + a run-loop guard), and **`tests/reconcile.bats`** covers the new path: provisioning from the mounted file, no-op when it's missing, ignoring other keys, and that sourcing doesn't start the loop.

## Validation
- Built the image: **320 MB**, confirmed `aws` is gone (`python3` remains only because `supervisor` needs it).
- `shellcheck` clean; **all 15 bats tests pass** (4 new) in a clean Debian container.
