### PR TITLE
ci: validate PR titles as Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,33 @@
+name: PR title
+
+# Releases are generated from commit history with semantic-release, and PRs are
+# expected to be squash-merged using the PR title as the commit subject. This
+# check enforces that the title is a valid Conventional Commit so the release
+# automation can derive the next version. See CONTRIBUTING.md.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            build
+            ci
+            docs
+            test
+            chore
+            revert

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,10 @@ Common types and how they affect the next version:
 A breaking change — either `type!: ...` or a `BREAKING CHANGE:` footer — triggers
 a **major** release.
 
+A CI check (`PR title`) validates that every pull-request title is a valid
+Conventional Commit. **Squash-merge** pull requests so the title becomes the
+commit subject on `master`; that is what the release automation reads.
+
 ## Releases
 
 Releases are not cut on merge. A scheduled workflow runs once a day; when there


### PR DESCRIPTION
## Summary
Ensures the release pipeline actually has releasable history to work with.

## Why
The daily `Release` workflow uses semantic-release, which derives the next version from **Conventional Commit** messages on `master`. If PRs are merged with non-conventional subjects, semantic-release finds nothing and **no release is ever cut** (which is the case so far — there are no tags yet).

## Change
- Adds a `PR title` check (`amannn/action-semantic-pull-request`) that validates every PR title against the allowed types (`feat`, `fix`, `perf`, `refactor`, `build`, `ci`, `docs`, `test`, `chore`, `revert`).
- Documents in CONTRIBUTING.md that PRs should be **squash-merged** so the validated title becomes the commit subject the release automation reads.

Least-privilege `pull-requests: read`. No application changes.