### PR TITLE
ci: add scheduled Docker release pipeline (monthly + manual)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,90 +1,125 @@
 name: Release
 
-# Releases are cut on a schedule, not on merge. Merging to master only runs CI
-# (see ci.yml); the actual versioned release + image publish happens here once a
-# day, and only when there are new releasable commits since the last tag.
+# Releases are NOT cut on merge to master — pushes only run CI.
+# Instead this job runs on a schedule (monthly): it determines the next
+# version from the Conventional Commits since the last tag. Only if there is a
+# release-worthy change (a feat/fix/breaking-change commit) does it create the
+# git tag, build and push the production Docker image to the GitHub Container
+# Registry (ghcr.io), and cut a GitHub Release. If nothing releasable has landed
+# since the last tag, `new_version` is empty and every release step is skipped —
+# a no-op run.
+#
+# To FORCE a release (e.g. after a docs-only or chore change), trigger it
+# manually and pick a bump level:
+#   * GitHub UI: Actions > Release > "Run workflow" > set "bump" to patch/minor/major.
+#   * CLI:       gh workflow run release.yml -f bump=patch
+# With `bump=auto` (the default) a manual run behaves exactly like the schedule:
+# it releases only if a feat/fix/breaking-change commit has landed.
+#
+# Version bump rules (mathieudutour/github-tag-action, Conventional Commits):
+#   - commit/PR title contains "BREAKING CHANGE" or "feat!:" -> major (x.0.0)
+#   - commit/PR title starts with "feat:"                    -> minor (0.x.0)
+#   - commit/PR title starts with "fix:"                     -> patch (0.0.x)
+#   - anything else                                          -> no release (skipped)
+
 on:
   schedule:
-    - cron: "0 6 * * *" # daily at 06:00 UTC
-  workflow_dispatch: # allow a manual release run
+    - cron: "0 5 1 * *" # monthly (first of the month, 05:00 UTC)
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Force a release with this bump when no releasable commits exist (auto = behave like the schedule)"
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
 
-permissions:
-  contents: write # create tags / GitHub releases
-  packages: write # push the image to GHCR
-  issues: write # semantic-release comments on released issues/PRs
-  pull-requests: write
-
+# Never run two releases at once.
 concurrency:
   group: release
   cancel-in-progress: false
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+permissions:
+  contents: write # create/push the git tag + release
+  packages: write # push the image to ghcr.io
 
 jobs:
   release:
-    name: Semantic release
     runs-on: ubuntu-latest
-    outputs:
-      published: ${{ steps.semantic.outputs.new_release_published }}
-      version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # full history so commit analysis sees every tag
+          ref: master
+          # Full history is required so the tagging action can read previous tags
+          # and compute the next semantic version.
+          fetch-depth: 0
 
-      - name: Run semantic-release
-        id: semantic
-        uses: cycjimmy/semantic-release-action@v6
+      - name: Determine next version
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
         with:
-          extra_plugins: |
-            conventional-changelog-conventionalcommits@^8
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v
+          # `default_bump` is the bump applied only when NO Conventional Commit
+          # since the last tag dictates one. Normally `false`, so non-releasable
+          # commits (docs, test, ci, chore, …) leave `new_version` empty and the
+          # release is skipped. A manual run can override it: passing
+          # bump=patch|minor|major forces that bump even on a docs-only change.
+          # A feat/fix/breaking-change commit always wins over this fallback.
+          default_bump: ${{ (github.event_name == 'workflow_dispatch' && inputs.bump != 'auto') && inputs.bump || false }}
+          release_branches: master
+
+      - name: Compute image metadata
+        if: steps.tag.outputs.new_version
+        id: meta
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.tag.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          # ghcr.io image names must be lowercase.
+          IMAGE="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          MAJOR="${VERSION%%.*}"
+          MINOR="${VERSION#*.}"; MINOR="${MINOR%%.*}"
+          {
+            echo "image=$IMAGE"
+            echo "tags=$IMAGE:$VERSION,$IMAGE:$MAJOR.$MINOR,$IMAGE:$MAJOR,$IMAGE:latest"
+          } >> "$GITHUB_OUTPUT"
 
-  publish-image:
-    name: Build & push image
-    needs: release
-    if: needs.release.outputs.published == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v7
+      - name: Set up Docker Buildx
+        if: steps.tag.outputs.new_version
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
+      - name: Log in to GitHub Container Registry
+        if: steps.tag.outputs.new_version
+        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Image metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.release.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.version }}
-            type=semver,pattern={{major}},value=${{ needs.release.outputs.version }}
-            type=raw,value=latest
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      - name: Build and push image
+        if: steps.tag.outputs.new_version
+        uses: docker/build-push-action@v6
         with:
           context: .
+          file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.new_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Create GitHub release
+        if: steps.tag.outputs.new_version
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.new_tag }}
+          name: ${{ steps.tag.outputs.new_tag }}
+          body: ${{ steps.tag.outputs.changelog }}


### PR DESCRIPTION
Adds a release pipeline consistent with the other repos.

- **Schedule:** monthly — first of the month at 05:00 UTC (`cron: 0 5 1 * *`).
- **Manual:** `workflow_dispatch` with an optional `bump` (auto/patch/minor/major), so a release can be forced on demand.
- **Behaviour:** determines the next version from Conventional Commits since the last tag (mathieudutour/github-tag-action). On a releasable commit it tags the version, builds the Docker image, pushes it to **ghcr.io** (`:VERSION`, `:MAJOR.MINOR`, `:MAJOR`, `:latest`), and cuts a GitHub Release. Nothing releasable → no-op.
- Uses the built-in `GITHUB_TOKEN`; no extra secrets required.