### PR TITLE
Security-only Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,26 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: daily
-      time: "10:00"
-    open-pull-requests-limit: 99
-    reviewers:
+      interval: monthly
+    # Security-only: disable routine version bumps; only open PRs for CVEs.
+    open-pull-requests-limit: 0
+    groups:
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    assignees:
       - diogopms
-
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 99
-    reviewers:
+      interval: monthly
+    # Security-only: disable routine version bumps; only open PRs for CVEs.
+    open-pull-requests-limit: 0
+    groups:
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    assignees:
       - diogopms


### PR DESCRIPTION
Adds/updates `.github/dependabot.yml` to a security-only policy:

- `open-pull-requests-limit: 0` disables routine version-bump PRs
- Dependabot only opens PRs for actual security advisories (CVEs)
- Security updates grouped into a single PR per ecosystem
- `interval: monthly`

Note: requires Dependabot security updates enabled in repo settings to take effect.